### PR TITLE
fix: support duplicate SmartBlock buttons with same label (#136)

### DIFF
--- a/src/utils/parseSmartBlockButton.ts
+++ b/src/utils/parseSmartBlockButton.ts
@@ -1,6 +1,10 @@
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 export const parseSmartBlockButton = (
   label: string,
-  text: string
+  text: string,
+  occurrenceIndex: number = 0
 ):
   | {
       index: number;
@@ -14,11 +18,22 @@ export const parseSmartBlockButton = (
   const trimmedLabel = label.trim();
   const buttonRegex = trimmedLabel
     ? new RegExp(
-        `{{(${trimmedLabel.replace(/\\+/g, "\\+")}):(?:42)?SmartBlock:(.*?)}}`
+        `{{(${escapeRegex(trimmedLabel)}):(?:42)?SmartBlock:(.*?)}}`,
+        "g"
       )
-    : /{{\s*:(?:42)?SmartBlock:(.*?)}}/;
-  const match = buttonRegex.exec(text);
-  if (!match) return null;
+    : /{{\s*:(?:42)?SmartBlock:(.*?)}}/g;
+
+  // Find all matches
+  const matches = Array.from(text.matchAll(buttonRegex));
+  if (
+    matches.length === 0 ||
+    occurrenceIndex < 0 ||
+    occurrenceIndex >= matches.length
+  ) {
+    return null;
+  }
+
+  const match = matches[occurrenceIndex];
   const index = match.index;
   const full = match[0];
   const buttonContent = trimmedLabel ? match[1] || "" : "";

--- a/tests/buttonParsing.test.ts
+++ b/tests/buttonParsing.test.ts
@@ -65,3 +65,68 @@ test("parses SmartBlock button for today's entry", () => {
     ButtonContent: "Create Today's Entry",
   });
 });
+
+test("parses multiple labeled SmartBlock buttons in the same block", () => {
+  const text =
+    "{{Run It:SmartBlock:WorkflowOne:RemoveButton=false}} and {{Run It:SmartBlock:WorkflowTwo:Icon=locate,Order=last}}";
+  const first = parseSmartBlockButton("Run It", text, 0);
+  const second = parseSmartBlockButton("Run It", text, 1);
+  expect(first?.workflowName).toBe("WorkflowOne");
+  expect(first?.variables).toMatchObject({
+    RemoveButton: "false",
+    ButtonContent: "Run It",
+  });
+  expect(second?.workflowName).toBe("WorkflowTwo");
+  expect(second?.variables).toMatchObject({
+    Icon: "locate",
+    Order: "last",
+    ButtonContent: "Run It",
+  });
+});
+
+test("parses multiple unlabeled SmartBlock buttons in the same block", () => {
+  const text =
+    "{{:SmartBlock:first:Icon=locate}} and {{:SmartBlock:second:RemoveButton=false}}";
+  const first = parseSmartBlockButton("", text, 0);
+  const second = parseSmartBlockButton("", text, 1);
+  expect(first?.buttonText).toBe("first:Icon=locate");
+  expect(first?.variables).toMatchObject({
+    Icon: "locate",
+    ButtonContent: "",
+  });
+  expect(second?.buttonText).toBe("second:RemoveButton=false");
+  expect(second?.variables).toMatchObject({
+    RemoveButton: "false",
+    ButtonContent: "",
+  });
+});
+
+test("returns null when occurrence index is out of bounds", () => {
+  const text = "{{Only One:SmartBlock:Workflow}}";
+  const result = parseSmartBlockButton("Only One", text, 2);
+  expect(result).toBeNull();
+});
+
+test("returns null when occurrence index is negative", () => {
+  const text = "{{Only One:SmartBlock:Workflow}}";
+  const result = parseSmartBlockButton("Only One", text, -1);
+  expect(result).toBeNull();
+});
+
+test("parses SmartBlock button label containing plus signs", () => {
+  const text = "{{Add+More:SmartBlock:PlusWorkflow}}";
+  const result = parseSmartBlockButton("Add+More", text);
+  expect(result?.workflowName).toBe("PlusWorkflow");
+  expect(result?.variables).toMatchObject({
+    ButtonContent: "Add+More",
+  });
+});
+
+test("parses SmartBlock button label with regex special characters", () => {
+  const text = "{{Add+(Test)[One]?:SmartBlock:WeirdWorkflow}}";
+  const result = parseSmartBlockButton("Add+(Test)[One]?", text);
+  expect(result?.workflowName).toBe("WeirdWorkflow");
+  expect(result?.variables).toMatchObject({
+    ButtonContent: "Add+(Test)[One]?",
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #136 - Enables multiple SmartBlock buttons with the same label in a single block to trigger their respective workflows correctly.

## Problem

When a block contains multiple buttons with identical labels:
```
{{b:SmartBlock:UserDNPToday:RemoveButton=false,Icon=archive}}
{{b:SmartBlock:UserDNPDateSelect:RemoveButton=false}}
```

Both buttons would trigger the first workflow (`UserDNPToday`) because `parseSmartBlockButton` always returned the first regex match.

## Solution

1. **Modified `parseSmartBlockButton.ts`**: Added an `occurrenceIndex` parameter that uses `matchAll()` to find all matching buttons and returns the Nth occurrence
2. **Modified `index.ts`**: Track button occurrence counts per block and pass the correct index when registering each button

### How it works:
- As buttons render in the DOM (in text order), each button with a given label gets an incrementing occurrence index
- First "b" button → `occurrenceIndex=0` → matches first `{{b:SmartBlock:...}}`
- Second "b" button → `occurrenceIndex=1` → matches second `{{b:SmartBlock:...}}`

### Backward compatibility:
- `occurrenceIndex` defaults to 0, so blocks with unique button labels work identically to before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SmartBlock buttons now distinguish multiple identical-label instances within the same block by tracking per-button occurrence so interactions target the correct instance.

* **Bug Fixes**
  * Improved occurrence-aware registration, cleanup and disconnection handling to avoid stale handlers and ensure counts are decremented reliably during dynamic updates and re-renders.

* **Tests**
  * Added tests covering multiple occurrences, out-of-bounds/negative indices, special-character labels, and correct per-occurrence parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
