### PR TITLE
fix: BLOCKMENTIONSDATED handles comma dates and 'first of' phrases (#54)

### DIFF
--- a/src/utils/splitSmartBlockArgs.ts
+++ b/src/utils/splitSmartBlockArgs.ts
@@ -1,0 +1,72 @@
+const MONTH_DAY_REGEX =
+  /^(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/i;
+const YEAR_REGEX = /^\d{4}$/;
+
+/**
+ * Re-joins "Month Day, Year" date tokens that were split on commas.
+ *
+ * BLOCKMENTIONSDATED signature: (limit, title, startDate, endDate, sort, format, ...search)
+ * Positions 0-1 (limit, title) are passed through unchanged.
+ * Starting at position 2, up to 2 date tokens are coalesced (startDate + endDate).
+ * The `mergedDates < 2` guard stops coalescing after both date slots are filled.
+ */
+const coalesceBlockMentionsDatedDates = (args: string[]) => {
+  const merged = args.slice(0, 2);
+  let i = 2;
+  let mergedDates = 0;
+  while (i < args.length) {
+    const current = args[i] || "";
+    const next = args[i + 1];
+    if (
+      mergedDates < 2 &&
+      typeof next === "string" &&
+      MONTH_DAY_REGEX.test(current.trim()) &&
+      YEAR_REGEX.test(next.trim())
+    ) {
+      merged.push(`${current.trimEnd()}, ${next.trimStart()}`);
+      i += 2;
+      mergedDates += 1;
+    } else {
+      merged.push(current);
+      i += 1;
+    }
+  }
+  return merged;
+};
+
+const splitSmartBlockArgs = (cmd: string, afterColon: string) => {
+  let commandStack = 0;
+  let pageRefStack = 0;
+  const args = [] as string[];
+  for (let i = 0; i < afterColon.length; i += 1) {
+    const cur = afterColon[i];
+    const prev = afterColon[i - 1];
+    const next = afterColon[i + 1];
+    if (cur === "%" && prev === "<") {
+      commandStack += 1;
+    } else if (cur === "%" && next === ">" && commandStack) {
+      commandStack -= 1;
+    } else if (cur === "[" && next === "[") {
+      pageRefStack += 1;
+    } else if (cur === "]" && prev === "]" && pageRefStack) {
+      pageRefStack -= 1;
+    }
+    if (cur === "," && !commandStack && !pageRefStack && prev !== "\\") {
+      args.push("");
+      continue;
+    } else if (cur === "\\" && next === ",") {
+      continue;
+    }
+    const current = args[args.length - 1] || "";
+    if (!args.length) {
+      args.push(cur);
+    } else {
+      args[args.length - 1] = `${current}${cur}`;
+    }
+  }
+  return cmd.toUpperCase() === "BLOCKMENTIONSDATED"
+    ? coalesceBlockMentionsDatedDates(args)
+    : args;
+};
+
+export default splitSmartBlockArgs;

--- a/tests/splitSmartBlockArgs.test.ts
+++ b/tests/splitSmartBlockArgs.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+import splitSmartBlockArgs from "../src/utils/splitSmartBlockArgs";
+
+test("splits nested smartblock commands as a single argument", () => {
+  expect(
+    splitSmartBlockArgs("ANYCOMMAND", "one,<%RANDOMNUMBER:1,10%>,two")
+  ).toEqual(["one", "<%RANDOMNUMBER:1,10%>", "two"]);
+});
+
+test("preserves commas in daily note page references", () => {
+  expect(
+    splitSmartBlockArgs(
+      "BLOCKMENTIONSDATED",
+      "10,DONE,[[January 24th, 2023]],[[January 1st, 2023]]"
+    )
+  ).toEqual(["10", "DONE", "[[January 24th, 2023]]", "[[January 1st, 2023]]"]);
+});
+
+test("coalesces month-day-year date tokens for BLOCKMENTIONSDATED", () => {
+  expect(
+    splitSmartBlockArgs(
+      "BLOCKMENTIONSDATED",
+      "10,DONE,February 1, 2023,February 24, 2023,DESC"
+    )
+  ).toEqual(["10", "DONE", "February 1, 2023", "February 24, 2023", "DESC"]);
+});
+
+test("handles unclosed [[ gracefully by treating rest as single arg", () => {
+  expect(
+    splitSmartBlockArgs("BLOCKMENTIONSDATED", "10,DONE,[[January 24th")
+  ).toEqual(["10", "DONE", "[[January 24th"]);
+});
+
+test("preserves commas inside nested page references", () => {
+  expect(
+    splitSmartBlockArgs(
+      "BLOCKMENTIONSDATED",
+      "10,DONE,[[January 24th, 2023]],today"
+    )
+  ).toEqual(["10", "DONE", "[[January 24th, 2023]]", "today"]);
+});
+
+test("coalesces at most two date tokens for BLOCKMENTIONSDATED", () => {
+  expect(
+    splitSmartBlockArgs(
+      "BLOCKMENTIONSDATED",
+      "10,DONE,January 1, 2023,February 1, 2023,March 1, 2023"
+    )
+  ).toEqual([
+    "10",
+    "DONE",
+    "January 1, 2023",
+    "February 1, 2023",
+    "March 1",
+    " 2023",
+  ]);
+});
+
+test("does not coalesce date tokens for non-BLOCKMENTIONSDATED commands", () => {
+  expect(
+    splitSmartBlockArgs("ANYCOMMAND", "January 1, 2023")
+  ).toEqual(["January 1", " 2023"]);
+});
+
+test("unclosed [[ in non-BLOCKMENTIONSDATED treats remaining as single arg", () => {
+  expect(
+    splitSmartBlockArgs("ANYCOMMAND", "one,[[unclosed,two,three")
+  ).toEqual(["one", "[[unclosed,two,three"]);
+});
+
+test("balanced [[ ]] followed by normal args splits correctly", () => {
+  expect(
+    splitSmartBlockArgs("ANYCOMMAND", "[[page ref]],normal,arg")
+  ).toEqual(["[[page ref]]", "normal", "arg"]);
+});


### PR DESCRIPTION
## Summary
- parse BLOCKMENTIONSDATED args robustly when dates contain commas
- normalize 'first of ...' to stable NLP parsing
- add regression tests for date-token coalescing and malformed refs

## Issue
Closes #54

## Summary by CodeRabbit

* **New Features**
  * Enhanced date handling to support block-mention date formats in date-based computations

* **Improvements**
  * Simplified command argument parsing logic for improved reliability and maintainability

* **Tests**
  * Added comprehensive test coverage for date parsing and argument tokenization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
