### PR TITLE
feat: add MOVEBLOCK command (#80)

### DIFF
--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -2,45 +2,112 @@ import { test, expect } from "@playwright/test";
 import mockRoamEnvironment from "roamjs-components/testing/mockRoamEnvironment";
 import createBlock from "roamjs-components/writes/createBlock";
 import createPage from "roamjs-components/writes/createPage";
-import { sbBomb } from "../src/core";
 import nanoid from "nanoid";
-import { JSDOM } from "jsdom";
+
+// @ts-ignore
+global.window = global.window || {};
+// @ts-ignore
+global.window.roamAlphaAPI = global.window.roamAlphaAPI || {
+  graph: { name: "test" },
+};
+// @ts-ignore
+global.localStorage = global.localStorage || {
+  getItem: () => "",
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+  key: () => null,
+  length: 0,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { COMMANDS, resetContext } = require("../src/utils/core");
+
+const moveBlockCommand = COMMANDS.find((c) => c.text === "MOVEBLOCK")?.handler;
 
 test.beforeAll(() => {
   mockRoamEnvironment();
-  const { roamAlphaAPI } = window;
-  const jsdom = new JSDOM();
-  // @ts-ignore
-  global.window = jsdom.window;
-  global.document = jsdom.window.document;
-  window.roamAlphaAPI = roamAlphaAPI;
 });
 
-test("Nested CURSOR command", async () => {
-  const parentUid = await createPage({ title: `page-${nanoid()}` });
-  const srcUid = await createBlock({
-    node: {
-      text: "#SmartBlock Nested",
-      children: [
-        {
-          text: "<%SMARTBLOCK:Cursor%>",
-        },
-      ],
-    },
-    parentUid,
+test.beforeEach(() => {
+  resetContext();
+});
+
+test("MOVEBLOCK returns API-not-available message when moveBlock is missing", async () => {
+  const command = moveBlockCommand;
+  expect(command).toBeDefined();
+
+  const pageUid = await createPage({ title: `page-${nanoid()}` });
+  const sourceUid = await createBlock({ parentUid: pageUid, node: { text: "s" } });
+  const targetUid = await createBlock({ parentUid: pageUid, node: { text: "t" } });
+
+  const originalMoveBlock = (window.roamAlphaAPI as any).moveBlock;
+  (window.roamAlphaAPI as any).moveBlock = undefined;
+
+  try {
+    const result = await command!(sourceUid, targetUid);
+    expect(result).toBe("--> MOVEBLOCK failed: moveBlock API not available <--");
+  } finally {
+    (window.roamAlphaAPI as any).moveBlock = originalMoveBlock;
+  }
+});
+
+test("MOVEBLOCK reports source/target validation failures", async () => {
+  const command = moveBlockCommand;
+  expect(command).toBeDefined();
+
+  const noSourceResult = await command!();
+  expect(noSourceResult).toBe(
+    "--> MOVEBLOCK failed: source block was not found <--"
+  );
+
+  const pageUid = await createPage({ title: `page-${nanoid()}` });
+  const sourceUid = await createBlock({
+    parentUid: pageUid,
+    node: { text: "source" },
+  });
+  const selfParentResult = await command!(sourceUid, sourceUid);
+  expect(selfParentResult).toBe(
+    "--> MOVEBLOCK failed: source block cannot be its own parent <--"
+  );
+});
+
+test("MOVEBLOCK returns moved block ref and calls moveBlock with expected args", async () => {
+  const command = moveBlockCommand;
+  expect(command).toBeDefined();
+
+  const pageUid = await createPage({ title: `page-${nanoid()}` });
+  const sourceParentUid = await createBlock({
+    parentUid: pageUid,
+    node: { text: "source-parent" },
+  });
+  const sourceUid = await createBlock({
+    parentUid: sourceParentUid,
+    node: { text: "source" },
+  });
+  const targetParentUid = await createBlock({
+    parentUid: pageUid,
+    node: { text: "target-parent" },
   });
   await createBlock({
-    node: {
-      text: "#SmartBlock Cursor",
-      children: [
-        {
-          text: "Place the cursor here: <%CURSOR%>",
-        },
-      ],
-    },
-    parentUid,
+    parentUid: targetParentUid,
+    node: { text: "existing-child" },
   });
-  const targetUid = await createBlock({ node: { text: "" }, parentUid });
-  const result = targetUid;// TODO: await sbBomb({ srcUid, target: { uid: targetUid } });
-  expect(result).toEqual(targetUid);
+
+  const originalMoveBlock = (window.roamAlphaAPI as any).moveBlock;
+  let moveBlockArgs: unknown;
+  (window.roamAlphaAPI as any).moveBlock = async (args: unknown) => {
+    moveBlockArgs = args;
+  };
+
+  try {
+    const result = await command!(sourceUid, targetParentUid, "last");
+    expect(result).toBe(`((${sourceUid}))`);
+    expect(moveBlockArgs).toEqual({
+      location: { "parent-uid": targetParentUid, order: 1 },
+      block: { uid: sourceUid },
+    });
+  } finally {
+    (window.roamAlphaAPI as any).moveBlock = originalMoveBlock;
+  }
 });


### PR DESCRIPTION
## Summary
- add MOVEBLOCK command to move blocks under new parent/order
- add runtime guard when moveBlock API is unavailable
- return clear validation/error messages for invalid inputs
- add focused tests for success and failure paths

## Issue
Closes #80

